### PR TITLE
Re-use SSL ctx to work with servers that mandate session re-use.

### DIFF
--- a/lib/Net/SSLGlue/FTP.pm
+++ b/lib/Net/SSLGlue/FTP.pm
@@ -200,6 +200,11 @@ BEGIN {
 	    close($listen);
 	}
 
+	# Re-use SSL context if present
+	my $sock = ${*$self}{sock};
+	my $ssl_ctx = ${*$sock}{'_SSL_ctx'};
+	${*$self}{'_SSL_ctx'} = $ssl_ctx if $ssl_ctx;
+
 	if (( ${*$self}{net_ftp_tlstype} || '') eq 'P'
 	    && ! $conn->start_SSL( $self->is_ssl ? ( 
 		    SSL_reuse_ctx => $self, 


### PR DESCRIPTION
The default configuration for vsftpd has 'require_ssl_reuse' set to YES and it requires the same session to be used for control and data connections. This explicit assignment has become necessary after the recent memory leak fix.